### PR TITLE
Colour contrast for accessibility

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -650,10 +650,12 @@ a i {
     padding-right: 0px;
 }
 
+/*Overriding search button background style*/
 .btn-default {
     background-color: #1a242f;
 }
 
+/*Overriding dashboard link box background style*/
 .panel-footer {
     background-color: #1a242f;
 }

--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -649,3 +649,11 @@ a i {
     padding-left: 0px;
     padding-right: 0px;
 }
+
+.btn-default {
+    background-color: #1a242f;
+}
+
+.panel-footer {
+    background-color: #1a242f;
+}


### PR DESCRIPTION
Originally, the lighthouse score for accessibility was 91.

To improve this score, I targeted the displayed warning regarding colour contrast. In particular, poor colour contrast was present in the "search" button and "view details" link button that was displayed on the main dashboard page. These issues were repaired by:

identifying the associated HTML class and id attributes of the buttons that were causing the accessibility issues
locating the file controlling the style rules for the front-end website, which was discovered to largely be controlled by the base.css file, located at Mayan-EDMS/mayan/apps/appearance/static/appearance/css
applying the necessary colour fixes using the class attributes of the problematic buttons
This change increased the accessibility lighthouse score by 2, taking it from 91 to 93.