### PR TITLE
Resolved Index Page Accessibility Issues (color contrast and unique ARIA ids)

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -11,6 +11,12 @@
         url('../fonts/IM_Fell_English_SC.ttf') format('truetype');
 }
 
+a {
+    color:rgb(79, 2, 15);
+  }
+a:hover {
+     color:rgb(79, 2, 15);
+}
 body {
     padding-top: 60px;
 }

--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -36,7 +36,7 @@
                                         </a>
                                     </h4>
                                 </div>
-                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
                                     <div class="panel-body">
                                         <ul class="list-unstyled">
                                             {% navigation_resolve_menu name=link.name as sub_menus_results %}
@@ -59,7 +59,7 @@
                             </div>
                         {% else %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                <div class="panel-heading" role="tab" id="headingThree">
                                     <h4 class="panel-title">
                                         {% include 'navigation/generic_link_instance.html' %}
                                     </h4>


### PR DESCRIPTION
Issue #8 was resolved. There were two main accessibility issues on the index page. The link to background color contrast was weak, and ARIA ids were repeated. To fix this, on the index page, I changed the link colors through the base CSS file and the ARIA ids in the main HTML file to be unique. Due to this, the accessibility score went from 89 to 98. 