### PR TITLE
Resolved Accessibility: Fix contrast issue through generic_form_subtemplate.html 

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -6,7 +6,7 @@
     {{ title }}
 </h4>
 <hr>
-{% endif %}
+{% endif %} {% test %}
 
 <div style="background-color: rgb(225, 198, 153);" class="well">
     {% if form.is_multipart %}

--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -6,7 +6,7 @@
     {{ title }}
 </h4>
 <hr>
-{% endif %} {% Test %}
+{% endif %}
 
 <div style="background-color: rgb(225, 198, 153);" class="well">
     {% if form.is_multipart %}

--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -8,7 +8,7 @@
 <hr>
 {% endif %}
 
-<div class="well">
+<div style="background-color: rgb(225, 198, 153);" class="well">
     {% if form.is_multipart %}
         <form action="{{ form_action }}" class="{{ form_css_classes|default:'' }}" enctype="multipart/form-data" method="{{ submit_method|default:'post' }}" name="{{ form.prefix|default:'' }}" target="{{ submit_target|default:'_self' }}">
     {% else %}
@@ -83,7 +83,7 @@
                         {% if submit_label %}{{ submit_label }}{% else %}{% if form.instance %}{% trans 'Save' %}{% else %}{% trans 'Submit' %}{% endif %}{% endif %}
                     </button>
                     {% if previous %}
-                          &nbsp;<a class="btn btn-default" onclick='history.back();'>
+                          &nbsp;<a style="background-color: blue;" class="btn btn-default" onclick='history.back();'>
                             <i class="fa fa-times"></i> {% if cancel_label %}{{ cancel_label }}{% else %}{% trans 'Cancel' %}{% endif %}
                           </a>
                     {% endif %}

--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -6,7 +6,7 @@
     {{ title }}
 </h4>
 <hr>
-{% endif %}
+{% endif %} {% Test %}
 
 <div style="background-color: rgb(225, 198, 153);" class="well">
     {% if form.is_multipart %}

--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -6,7 +6,7 @@
     {{ title }}
 </h4>
 <hr>
-{% endif %} {% test %}
+{% endif %}
 
 <div style="background-color: rgb(225, 198, 153);" class="well">
     {% if form.is_multipart %}


### PR DESCRIPTION
The score for accessibility was 82, and it was improved to 85.

I Resolved this by changing the color of two classes:
(1) one class was controlling the background of the overall form, which changed to beige ('well' class)
(2) the other class was controlling the background color of the cancel button, which changed to blue ('btn btn-default')

These changes were made in the generic_form_subtemplate.html file found in:
Mayan-EDMS/mayan/apps/appearance/templates/appearance)/generic_form_subtemplate.html

Resolved #16 