### PR TITLE
Unique ARIA ids created for main-menu panel

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -21,7 +21,7 @@
                     {% with ' ' as link_classes %}
                         {% if link|common_get_type == "<class 'mayan.apps.navigation.classes.Menu'>" %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                <div class="panel-heading" role="tab" id="headingOne-{{ forloop.counter }}">
                                     <h4 class="panel-title">
                                         <a class="non-ajax collapsed" role="button" data-toggle="collapse" data-parent="#accordion-sidebar" href="#accordion-body-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapseOne">
                                             <div class="pull-left">
@@ -36,7 +36,7 @@
                                         </a>
                                     </h4>
                                 </div>
-                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne-{{ forloop.counter }}">
                                     <div class="panel-body">
                                         <ul class="list-unstyled">
                                             {% navigation_resolve_menu name=link.name as sub_menus_results %}
@@ -59,7 +59,7 @@
                             </div>
                         {% else %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                <div class="panel-heading" role="tab" id="headingOne-{{ forloop.counter }}">
                                     <h4 class="panel-title">
                                         {% include 'navigation/generic_link_instance.html' %}
                                     </h4>


### PR DESCRIPTION
The accessibility score on Create Tag page increased from **85** to **91**.
It also increases the accessibility score **by 6 points** _on every page showing the main-menu panel_ on the left.

_**Issue description**_

The menu panel on the left uses a **for loop**  to render the panel headings. However, the ids were all named "headingOne". According to [web.dev](https://web.dev/duplicate-id-aria/), using the same ID on more than one element may cause screen readers and other assistive technologies to only announce the first element with the shared ID, preventing users from accessing the later elements.

_**Solution Implemented**_

I associated the id with a for loop counter, which would associate a unique iteration number in the id and thus resolve the issue.  For example, the second panel item now shows "headingOne-2" instead of "headingOne".

resolves #40 