### PR TITLE
Resolves non-unique ARIA Ids in the navigation menu

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -36,7 +36,7 @@
                                         </a>
                                     </h4>
                                 </div>
-                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
                                     <div class="panel-body">
                                         <ul class="list-unstyled">
                                             {% navigation_resolve_menu name=link.name as sub_menus_results %}
@@ -59,7 +59,7 @@
                             </div>
                         {% else %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                <div class="panel-heading" role="tab" id="headingThree">
                                     <h4 class="panel-title">
                                         {% include 'navigation/generic_link_instance.html' %}
                                     </h4>


### PR DESCRIPTION
Resolves https://github.com/CMU-17313Q/Mayan-EDMS/issues/25
Changed the repeated "headingOne" ids in the menu_main.html file by assigning different id names on lines 39 and 62 to "headingTwo" and "headingThree".
The lighthouse accessibility score improved from 91 to 98.